### PR TITLE
[FEAT] Add cicd for frontend

### DIFF
--- a/.github/workflows/frontend-ci-cd.yml
+++ b/.github/workflows/frontend-ci-cd.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  frontend-check:
+  build-and-test:
     runs-on: ubuntu-latest
     env:
       VITE_API_URL: ${{ secrets.VITE_API_URL }}
@@ -31,6 +31,29 @@ jobs:
       # Uncomment this if you want linting enabled
       # - name: Lint
       #   run: npm --prefix web run lint
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    env:
+      VITE_API_URL: ${{ secrets.VITE_API_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.3.0'
+          cache: 'npm'
+          cache-dependency-path: 'web/package-lock.json'
+
+      - name: Install dependencies
+        run: npm --prefix web ci --legacy-peer-deps
+
+      - name: Build (TS compile + Vite build)
+        run: npm --prefix web run build
 
       - name: Setup Python for upload step
         uses: actions/setup-python@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration and deployment of the frontend application. The workflow automates building the frontend, installing dependencies, and securely uploading the build artifacts to a hosting service. This streamlines the deployment process and improves reliability for frontend changes.

**Frontend CI/CD automation:**

* Added `.github/workflows/frontend-ci-cd.yml` to define a workflow that builds the frontend on pull requests to `main`, installs dependencies, and runs the build process using Node.js and Vite.

**Automated deployment to hosting service:**

* Implemented a deployment step that uploads the built frontend (`dist` folder) to a hosting service using a Python script, authenticating via environment secrets and handling file uploads recursively.
* Added secure management of API and hosting credentials via GitHub secrets to ensure sensitive data is not exposed in the workflow.

**Tooling and environment setup:**

* Configured the workflow to use specific versions of Node.js (`24.3.0`) and Python (`3.12.5`) to ensure consistent builds and compatibility.
* Provided an optional linting step (commented out) for future code quality checks.

Closes #11 