### PR TITLE
[FIX] Fix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Ensure shell scripts always use LF line endings
+*.sh text eol=lf
+docker-entrypoint.sh text eol=lf
+
+# Python files
+*.py text eol=lf
+
+# Configuration files
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.ini text eol=lf
+
+# Docker files
+Dockerfile text eol=lf
+*.dockerfile text eol=lf
+.dockerignore text eol=lf
+
+# Other text files
+*.md text eol=lf
+*.txt text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -15,8 +15,9 @@ RUN useradd -m -u 1000 appuser
 
 COPY . .
 
-# Set ownership and permissions
-RUN chown -R appuser:appuser /app && \
+# Convert line endings (CRLF to LF) and set ownership/permissions
+RUN sed -i 's/\r$//' /app/docker-entrypoint.sh && \
+    chown -R appuser:appuser /app && \
     chmod +x /app/docker-entrypoint.sh
 
 # Switch to non-root user


### PR DESCRIPTION
This pull request focuses on standardizing line endings across the project and ensuring proper handling of shell scripts in the Docker build process. The most important changes include the addition of a `.gitattributes` file to enforce LF line endings for relevant files and an update to the Dockerfile to convert line endings for the entrypoint script.

**Line ending standardization:**

* Added `.gitattributes` to enforce LF line endings for shell scripts, Python files, configuration files, Docker files, and other text files, while marking common binary files as binary to prevent line ending conversion.

**Dockerfile improvements:**

* Updated `api/Dockerfile` to convert CRLF to LF in `docker-entrypoint.sh` using `sed`, ensuring compatibility in Unix environments before setting ownership and permissions.

Closes #17 